### PR TITLE
Introduce buildUrl to safely build URLs to the incident.io dashboard

### DIFF
--- a/incident/package.json
+++ b/incident/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@incident-io/backstage",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",

--- a/incident/src/components/EntityIncidentCard/index.tsx
+++ b/incident/src/components/EntityIncidentCard/index.tsx
@@ -39,7 +39,7 @@ import React, { useState } from "react";
 import { useAsync } from "react-use";
 import { IncidentApiRef } from "../../api/client";
 import { definitions } from "../../api/types";
-import { getBaseUrl } from "../../config";
+import { buildUrl } from "../../config";
 import { IncidentListItem } from "../IncidentListItem";
 
 // The card displayed on the entity page showing a handful of the most recent
@@ -50,7 +50,6 @@ export const EntityIncidentCard = ({
   maxIncidents?: number;
 }) => {
   const config = useApi(configApiRef);
-  const baseUrl = getBaseUrl(config);
   const { entity } = useEntity();
 
   const IncidentApi = useApi(IncidentApiRef);
@@ -78,14 +77,14 @@ export const EntityIncidentCard = ({
     label: "Create incident",
     disabled: false,
     icon: <WhatshotIcon />,
-    href: `${baseUrl}/incidents/create`,
+    href: buildUrl(config, "incidents/create"),
   };
 
   const viewIncidentsLink: IconLinkVerticalProps = {
     label: "View past incidents",
     disabled: false,
     icon: <HistoryIcon />,
-    href: `${baseUrl}/incidents?${query.toString()}`,
+    href: buildUrl(config, "incidents", query),
   };
 
   const {
@@ -143,11 +142,7 @@ export const EntityIncidentCard = ({
             <List dense>
               {incidents?.slice(0, maxIncidents)?.map((incident) => {
                 return (
-                  <IncidentListItem
-                    key={incident.id}
-                    incident={incident}
-                    baseUrl={baseUrl}
-                  />
+                  <IncidentListItem key={incident.id} incident={incident} />
                 );
               })}
             </List>
@@ -155,7 +150,7 @@ export const EntityIncidentCard = ({
               Click to{" "}
               <Link
                 target="_blank"
-                href={`${baseUrl}/incidents?${queryLive.toString()}`}
+                href={buildUrl(config, "incidents", queryLive)}
               >
                 see more.
               </Link>

--- a/incident/src/components/IncidentListItem/index.tsx
+++ b/incident/src/components/IncidentListItem/index.tsx
@@ -13,8 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { DateTime, Duration } from 'luxon';
-import { BackstageTheme } from '@backstage/theme';
+import { DateTime, Duration } from "luxon";
+import { configApiRef, useApi } from "@backstage/core-plugin-api";
+import { BackstageTheme } from "@backstage/theme";
 import {
   Chip,
   IconButton,
@@ -24,27 +25,28 @@ import {
   Tooltip,
   Typography,
   makeStyles,
-} from '@material-ui/core';
-import OpenInBrowserIcon from '@material-ui/icons/OpenInBrowser';
-import React from 'react';
-import { definitions } from '../../api/types';
+} from "@material-ui/core";
+import OpenInBrowserIcon from "@material-ui/icons/OpenInBrowser";
+import React from "react";
+import { definitions } from "../../api/types";
+import { buildUrl } from "../../config";
 
-const useStyles = makeStyles<BackstageTheme>(theme => ({
+const useStyles = makeStyles<BackstageTheme>((theme) => ({
   listItemPrimary: {
-    display: 'flex', // vertically align with chip
-    fontWeight: 'bold',
+    display: "flex", // vertically align with chip
+    fontWeight: "bold",
   },
   warning: {
     borderColor: theme.palette.status.warning,
     color: theme.palette.status.warning,
-    '& *': {
+    "& *": {
       color: theme.palette.status.warning,
     },
   },
   error: {
     borderColor: theme.palette.status.error,
     color: theme.palette.status.error,
-    '& *': {
+    "& *": {
       color: theme.palette.status.error,
     },
   },
@@ -52,15 +54,15 @@ const useStyles = makeStyles<BackstageTheme>(theme => ({
 
 // Single item in the list of on-going incidents.
 export const IncidentListItem = ({
-  baseUrl,
   incident,
 }: {
-  baseUrl: string;
-  incident: definitions['IncidentV2ResponseBody'];
+  incident: definitions["IncidentV2ResponseBody"];
 }) => {
+  const config = useApi(configApiRef);
+
   const classes = useStyles();
-  const reportedAt = incident.incident_timestamp_values?.find(ts =>
-    ts.incident_timestamp.name.match(/reported/i),
+  const reportedAt = incident.incident_timestamp_values?.find((ts) =>
+    ts.incident_timestamp.name.match(/reported/i)
   );
 
   // If reported isn't here for some reason, use created at.
@@ -70,9 +72,9 @@ export const IncidentListItem = ({
     new Date().getTime() - new Date(reportedAtDate).getTime();
   const sinceReportedLabel = DateTime.local()
     .minus(Duration.fromMillis(sinceReported))
-    .toRelative({ locale: 'en' });
-  const lead = incident.incident_role_assignments.find(roleAssignment => {
-    return roleAssignment.role.role_type === 'lead';
+    .toRelative({ locale: "en" });
+  const lead = incident.incident_role_assignments.find((roleAssignment) => {
+    return roleAssignment.role.role_type === "lead";
   });
 
   return (
@@ -86,7 +88,7 @@ export const IncidentListItem = ({
               size="small"
               variant="outlined"
               className={
-                ['live'].includes(incident.incident_status.category)
+                ["live"].includes(incident.incident_status.category)
                   ? classes.error
                   : classes.warning
               }
@@ -95,15 +97,15 @@ export const IncidentListItem = ({
           </>
         }
         primaryTypographyProps={{
-          variant: 'body1',
+          variant: "body1",
           className: classes.listItemPrimary,
         }}
         secondary={
           <Typography noWrap variant="body2" color="textSecondary">
-            Reported {sinceReportedLabel} and{' '}
+            Reported {sinceReportedLabel} and{" "}
             {lead?.assignee
               ? `${lead.assignee.name} is lead`
-              : 'the lead is unassigned'}
+              : "the lead is unassigned"}
             .
           </Typography>
         }
@@ -111,7 +113,7 @@ export const IncidentListItem = ({
       <ListItemSecondaryAction>
         <Tooltip title="View in incident.io" placement="top">
           <IconButton
-            href={`${baseUrl}/incidents/${incident.id}`}
+            href={buildUrl(config, `incidents/${incident.id}`)}
             target="_blank"
             rel="noopener noreferrer"
             color="primary"

--- a/incident/src/config.ts
+++ b/incident/src/config.ts
@@ -13,18 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ConfigApi } from '@backstage/core-plugin-api';
+import { ConfigApi } from "@backstage/core-plugin-api";
 
 // Find the baseUrl of the incident dashboard.
-export function getBaseUrl(config: ConfigApi) {
+function getBaseUrl(config: ConfigApi) {
   try {
-    const baseUrl = config.getString('incident.baseUrl');
-    if (baseUrl !== '') {
-      return baseUrl;
+    const baseUrl = config.getString("incident.baseUrl");
+    if (baseUrl !== "") {
+      return new URL(baseUrl);
     }
   } catch (e) {
     // no action
   }
 
-  return 'https://app.incident.io';
+  return new URL("https://app.incident.io");
+}
+
+// Build a URL to the incident.io dashboard.
+export function buildUrl(
+  config: ConfigApi,
+  path: string,
+  query: URLSearchParams = new URLSearchParams()
+): string {
+  const baseUrl = getBaseUrl(config);
+  // Allocate a new URL
+  const url = new URL(path, baseUrl);
+  url.search = query.toString();
+
+  return url.toString();
 }


### PR DESCRIPTION
It seems like `URLSearchParams.toString` includes a `?` on some platforms and does not include it on others, although I can't find a source that agrees with this.

This attempts to work around that by building a `URL` object and then `.toString`-ing that, which hopefully means that the platform matches the behaviour of `URL.searchParams` and setting `URL.search`.