### PR TITLE
Remove unused plugin-cost-insights

### DIFF
--- a/incident/package.json
+++ b/incident/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@incident-io/backstage",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "Apache-2.0",
@@ -29,7 +29,6 @@
     "@backstage/core-plugin-api": "^1.5.2",
     "@backstage/errors": "^1.2.0",
     "@backstage/plugin-catalog-react": "^1.7.0",
-    "@backstage/plugin-cost-insights": "^0.12.8",
     "@backstage/plugin-search-react": "^1.6.2",
     "@backstage/theme": "^0.4.0",
     "@material-ui/core": "^4.9.13",


### PR DESCRIPTION
We're not using this in the incident plugin, and it requires additional setup.