### PR TITLE
Remove unused config from schema

### DIFF
--- a/incident/config.d.ts
+++ b/incident/config.d.ts
@@ -19,12 +19,6 @@ export interface Config {
    */
   incident?: {
     /**
-     * The API key that provides access to the incident.io API.
-     * @see https://app.incident.io/settings/api-keys
-     */
-    apiKey: string;
-
-    /**
      * The base URL of the incident dashboard, only useful in development.
      * @visibility frontend
      */


### PR DESCRIPTION
apiKey doesnt appear to be used anywhere or mentioned in the code as users are instructed to use the proxy endpoint.

Removal will fix config validation issues when this field is missing.
Originally considered making it optional but determined it was unused so I removed it.