### PR TITLE
feat(entitycard): avoid sending namespace to incidentio

### DIFF
--- a/incident/README.md
+++ b/incident/README.md
@@ -55,6 +55,12 @@ tag:
 </Grid>
 ```
 
+You can also use `maxIncidents` variable to define the number of incidents you want 
+and `useNamespace` option to avoid using Backstage Namespace when querying incident.io.
+```ts
+<EntityIncidentCard maxIncidents={2} useNamespace={false} />
+```
+
 If you want to include the list of incidents in places like the page for a
 system, it's worth noting that `overviewContent` isn't reused on every page.
 You may find you need to make more edits to `EntityPage`, based on your setup.

--- a/incident/src/components/EntityIncidentCard/index.tsx
+++ b/incident/src/components/EntityIncidentCard/index.tsx
@@ -59,8 +59,10 @@ const IncorrectConfigCard = () => {
 // incidents that are on-going for that component.
 export const EntityIncidentCard = ({
   maxIncidents = 2,
+  useNamespace = true
 }: {
   maxIncidents?: number;
+  useNamespace?: boolean;
 }) => {
   const config = useApi(configApiRef);
   const { entity } = useEntity();
@@ -73,7 +75,9 @@ export const EntityIncidentCard = ({
   const [reload, setReload] = useState(false);
 
   const entityFieldID = getEntityFieldID(config, entity);
-  const entityID = `${entity.metadata.namespace}/${entity.metadata.name}`;
+  const entityID = useNamespace
+    ? `${entity.metadata.namespace}/${entity.metadata.name}`
+    : `${entity.metadata.name}`;
 
   // This query filters incidents for those that are associated with this
   // entity.


### PR DESCRIPTION
Add an option for the EntityIncidentCard component to avoid sending the Namespace during the API call.

Example:
```
useNamespace={true}:
default/my-service

useNamespace={false}:
my-service
```