### PR TITLE
Allow for custom_fields to be mapped to entities outside of backstage

### DIFF
--- a/incident/src/components/EntityIncidentCard/index.tsx
+++ b/incident/src/components/EntityIncidentCard/index.tsx
@@ -73,7 +73,7 @@ export const EntityIncidentCard = ({
   const [reload, setReload] = useState(false);
 
   const entityFieldID = getEntityFieldID(config, entity);
-  const entityID = `${entity.metadata.namespace}/${entity.metadata.name}`;
+  const entityID = `${entity.metadata.namespace}/${entity.metadata.name}, ${entity.metadata.name} `;
 
   // This query filters incidents for those that are associated with this
   // entity.


### PR DESCRIPTION
In my implementation of backstage the namespace is called `default` 
And I have a  custom_field called `service` that is mapped to catalog from another source (not backstage). 
Which essentially means when i try to run the plugin against my incident.io api 

the call translates to 

http://localhost:7000/api/proxy/incident/api/v2/incidents?custom_field[field ID here][one_of]=[default/service-name]

This is causing problems because the custom field is pulling the names of services without any knowledge of what backstage metadata namespace is (in this case default)

So all the plugin queries return no incidents since the custom-field assigned to incidents is `<service-name>` and not default/service-name

This PR allows for option to include one of the 2 available field values with and without backstage namespace. 
