### PR TITLE
Use FetchApi instead of standard fetch on proxy client

### DIFF
--- a/incident/src/api/client.ts
+++ b/incident/src/api/client.ts
@@ -15,7 +15,7 @@
  */
 import {
   DiscoveryApi,
-  IdentityApi,
+  FetchApi,
   createApiRef,
 } from "@backstage/core-plugin-api";
 
@@ -41,18 +41,18 @@ const DEFAULT_PROXY_PATH = "/incident/api";
 
 type Options = {
   discoveryApi: DiscoveryApi;
-  identityApi: IdentityApi;
+  fetchApi: FetchApi,
   proxyPath?: string;
 };
 
 export class IncidentApi implements Incident {
   private readonly discoveryApi: DiscoveryApi;
-  private readonly identityApi: IdentityApi;
+  private readonly fetchApi: FetchApi;
   private readonly proxyPath: string;
 
   constructor(opts: Options) {
     this.discoveryApi = opts.discoveryApi;
-    this.identityApi = opts.identityApi;
+    this.fetchApi = opts.fetchApi;
     this.proxyPath = opts.proxyPath ?? DEFAULT_PROXY_PATH;
   }
 
@@ -67,14 +67,10 @@ export class IncidentApi implements Incident {
   }): Promise<T> {
     const apiUrl =
       (await this.discoveryApi.getBaseUrl("proxy")) + this.proxyPath;
-    const { token } = await this.identityApi.getCredentials();
 
-    const resp = await fetch(`${apiUrl}${path}`, {
+    const resp = await this.fetchApi.fetch(`${apiUrl}${path}`, {
       method: method,
       body: body,
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
     });
     if (!resp.ok) {
       throw new Error(`${resp.status} ${resp.statusText}`);

--- a/incident/src/plugin.ts
+++ b/incident/src/plugin.ts
@@ -18,7 +18,7 @@ import {
   createComponentExtension,
   createPlugin,
   discoveryApiRef,
-  identityApiRef,
+  fetchApiRef,
 } from "@backstage/core-plugin-api";
 import {CardExtensionProps, createCardExtension} from "@backstage/plugin-home-react";
 
@@ -29,11 +29,14 @@ export const incidentPlugin = createPlugin({
   apis: [
     createApiFactory({
       api: IncidentApiRef,
-      deps: { discoveryApi: discoveryApiRef, identityApi: identityApiRef },
-      factory: ({ discoveryApi, identityApi }) => {
+      deps: { 
+        discoveryApi: discoveryApiRef, 
+        fetchApi: fetchApiRef,
+      },
+      factory: ({ discoveryApi, fetchApi }) => {
         return new IncidentApi({
           discoveryApi: discoveryApi,
-          identityApi: identityApi,
+          fetchApi: fetchApi,
         });
       },
     }),

--- a/incident/yarn.lock
+++ b/incident/yarn.lock
@@ -14895,7 +14895,16 @@ string-length@^4.0.1:
     char-regex "^1.0.2"
     strip-ansi "^6.0.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -14969,7 +14978,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -14982,6 +14991,13 @@ strip-ansi@5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -16208,7 +16224,7 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -16221,6 +16237,15 @@ wrap-ansi@^6.0.1:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
This pull request should not change any behavior on this plugin, it simply moves from using standard `fetch` to using Backstage's [FetchApi](https://backstage.io/docs/reference/core-plugin-api.fetchapiref/).

Even though the plugin behavior has not changed this is important for my org to be able to adopt this plugin due to some authorization tweaks we have to make on the requests.

I have tested these changes on my org's workspace and its working as expected 
<img width="990" alt="image" src="https://github.com/user-attachments/assets/1bc94f19-e534-4faa-897e-0bc2fef7641c">
