### PR TITLE
chore: remove unused moment lib

### DIFF
--- a/incident/package.json
+++ b/incident/package.json
@@ -42,7 +42,6 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.60",
     "luxon": "^3.3.0",
-    "moment": "^2.29.4",
     "qs": "^6.11.2",
     "react-use": "^17.2.4"
   },

--- a/incident/yarn.lock
+++ b/incident/yarn.lock
@@ -12197,11 +12197,6 @@ mkdirp@^1.0.3:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-moment@^2.29.4:
-  version "2.30.1"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
-  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
-
 morgan@^1.10.0:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.10.0.tgz#091778abc1fc47cd3509824653dae1faab6b17d7"


### PR DESCRIPTION
Hey 👋 

This package already uses luxon, as most Backstage plugins (cf https://backstage.io/docs/architecture-decisions/adrs-adr010). It can thus be safely removed from dependencies.

One less dependency for consumers!

Have a great day!