### PR TITLE
added entity and home page alert cards

### DIFF
--- a/incident/src/alpha.tsx
+++ b/incident/src/alpha.tsx
@@ -36,6 +36,14 @@ const entityIncidentCard = EntityCardBlueprint.make({
   },
 });
 
+const entityAlertCard = EntityCardBlueprint.make({
+  name: "EntityAlertCard",
+  params: {
+    loader: async () => 
+      import("./components/EntityAlertCard").then(m=><m.EntityAlertCard />),
+  },
+});
+
 const homePageIncidentCard = HomePageWidgetBlueprint.make({
   name: "HomePageIncidentCard",
   params: {
@@ -67,10 +75,21 @@ const homePageIncidentCard = HomePageWidgetBlueprint.make({
     },
   },
 });
+
+
+const homePageAlertCard = HomePageWidgetBlueprint.make({
+  name: "HomePageAlertCard",
+  params: {
+    title: "Ongoing Alerts",    
+    components: () => import("./components/HomePageAlertCard"),
+  },
+});
+
+
    
 const plugin: FrontendPlugin = createFrontendPlugin({                                                                                         
     pluginId: "incident",
-    extensions: [incidentApi, entityIncidentCard, homePageIncidentCard],                                                                        
+    extensions: [incidentApi, entityIncidentCard, entityAlertCard, homePageIncidentCard, homePageAlertCard],                                                                        
   });             
 
 export default plugin;

--- a/incident/src/api/types.ts
+++ b/incident/src/api/types.ts
@@ -11727,6 +11727,100 @@ export interface definitions {
      */
     id: string;
   };
+  //alert types
+  AlertAttributeValue: {
+    catalog_entry?: {
+      catalog_type_id: string;
+      id: string;
+      name: string;
+    };
+    label?: string;
+    literal?: string;
+  };
+  AlertAttributeEntry: {
+    array_value?: definitions["AlertAttributeValue"][];
+    attribute: {
+      array: boolean;
+      emoji?: string;
+      id: string;
+      name: string;
+      required: boolean;
+      type: string;
+    };
+    value?: definitions["AlertAttributeValue"];
+  };
+  AlertV2: {
+    alert_source_id: string;
+    attributes: definitions["AlertAttributeEntry"][];
+    created_at: string;
+    deduplication_key: string;
+    description?: string;
+    id: string;
+    resolved_at?: string;
+    source_url?: string;
+    status: "firing" | "resolved";
+    title: string;
+    /** @enum {string} */
+    updated_at: string;
+  };
+  AlertsV2ListResponseBody: {
+    alerts: definitions["AlertV2"][];
+    pagination_meta: {
+      after?: string;
+      page_size: number;
+    };
+  };
+  AlertSourceV2: {
+    id: string;
+    name: string;
+    source_type: string;
+  };
+  AlertSourcesV2ListResponseBody: {
+    alert_sources: definitions["AlertSourceV2"][];
+  };
+  AlertAttributeDefinition: {
+    id: string;
+    name: string;
+    type: string;
+    array: boolean;
+    emoji?: string;
+    required: boolean;
+  };
+  AlertAttributesV2ListResponseBody: {
+    alert_attributes: definitions["AlertAttributeDefinition"][];
+  };
+  IncidentAlertV2: {
+    id: string;
+    alert_route_id: string;
+    alert: {
+      id: string;
+      alert_source_id: string;
+      created_at: string;
+      updated_at: string;
+      resolved_at?: string;
+      deduplication_key: string;
+      description?: string;
+      source_url?: string;
+      status: "firing" | "resolved";
+      title: string;
+    };
+    incident: {
+      id: string;
+      external_id: number;
+      name: string;
+      reference: string;
+      status_category: string;
+      summary?: string;
+      visibility: string;
+    };
+  };
+  IncidentAlertsV2ListResponseBody: {
+    incident_alerts: definitions["IncidentAlertV2"][];
+    pagination_meta: {
+      after?: string;
+      page_size: number;
+    };
+  };
 }
 
 export interface operations {

--- a/incident/src/api/types.ts
+++ b/incident/src/api/types.ts
@@ -11727,7 +11727,7 @@ export interface definitions {
      */
     id: string;
   };
-  //alert types
+  // alert types
   AlertAttributeValue: {
     catalog_entry?: {
       catalog_type_id: string;

--- a/incident/src/components/AlertListItem/index.tsx
+++ b/incident/src/components/AlertListItem/index.tsx
@@ -44,7 +44,7 @@ export const AlertListItem = ({
               className={
                 ["firing"].includes(alert.status)
                   ? classes.error
-                  : classes.warning
+                  : classes.success
               }
             />
             {alert.title}

--- a/incident/src/components/AlertListItem/index.tsx
+++ b/incident/src/components/AlertListItem/index.tsx
@@ -1,0 +1,85 @@
+import { DateTime, Duration } from "luxon";
+import {
+  Chip,
+  IconButton,
+  ListItem,
+  ListItemSecondaryAction,
+  ListItemText,
+  Tooltip,
+  Typography,
+} from "@material-ui/core";
+import OpenInBrowserIcon from "@material-ui/icons/OpenInBrowser";
+import { definitions } from "../../api/types";
+import { useStyles } from "../IncidentListItem";
+
+// Single item in the list of on-going alerts.
+export const AlertListItem = ({
+  baseUrl,
+  alert,
+  source,
+  priority
+}: {
+  baseUrl: string;
+  alert: definitions["AlertV2"];
+  source: string;
+  priority?: string; 
+}) => {
+  const classes = useStyles();
+
+  const sinceCreated = new Date().getTime() - new Date(alert.created_at).getTime();
+  const sinceCreatedLabel = DateTime.local()
+    .minus(Duration.fromMillis(sinceCreated))
+    .toRelative({ locale: "en" });
+
+  return (
+    <ListItem dense key={alert.id}>
+      <ListItemText
+        primary={
+          <>
+            <Chip
+              data-testid={`chip-${alert.status}`}
+              label={alert.status}
+              size="small"
+              variant="outlined"
+              className={
+                ["firing"].includes(alert.status)
+                  ? classes.error
+                  : classes.warning
+              }
+            />
+            {alert.title}
+            {priority && (
+              <Chip
+                data-testid={`chip-${priority}`}
+                label={priority}
+                size="small"
+                variant="outlined"
+              />
+            )}
+          </>
+        }
+        primaryTypographyProps={{
+          variant: "body1",
+          className: classes.listItemPrimary,
+        }}
+        secondary={
+          <Typography noWrap variant="body2" color="textSecondary">
+            Created {sinceCreatedLabel} from {source}.
+          </Typography>
+        }
+      />
+      <ListItemSecondaryAction>
+        <Tooltip title="View in incident.io" placement="top">
+          <IconButton
+            href={`${baseUrl}/on-call/alerts/${alert.id}/details`}
+            target="_blank"
+            rel="noopener noreferrer"
+            color="primary"
+          >
+            <OpenInBrowserIcon />
+          </IconButton>
+        </Tooltip>
+      </ListItemSecondaryAction>
+    </ListItem>
+  );
+};

--- a/incident/src/components/EntityAlertCard/index.test.tsx
+++ b/incident/src/components/EntityAlertCard/index.test.tsx
@@ -1,0 +1,242 @@
+/// <reference types="@testing-library/jest-dom" />
+import { render, screen } from "@testing-library/react";
+import { vi } from "vitest";
+
+vi.mock("@backstage/core-plugin-api", () => ({
+  useApi: vi.fn(),
+  configApiRef: {},
+}));
+
+vi.mock("@backstage/plugin-catalog-react", () => ({
+  useEntity: vi.fn(),
+}));
+
+vi.mock("../../hooks/useIncidentRequest", () => ({
+  useIncidentList: vi.fn(),
+  useIncidentAlertList: vi.fn(),
+  useAlertList: vi.fn(),
+  useAlertSourceList: vi.fn(),
+  useIdentity: vi.fn(),
+}));
+
+vi.mock("@backstage/core-components", () => ({
+  Progress: () => <div data-testid="progress" />,
+}));
+
+vi.mock("../AlertListItem", () => ({
+  AlertListItem: ({ alert }: any) => (
+    <div data-testid={`alert-${alert.id}`}>{alert.title}</div>
+  ),
+}));
+
+vi.mock("../EntityIncidentCard", () => ({
+  getEntityFieldID: vi.fn(),
+}));
+
+import { useApi } from "@backstage/core-plugin-api";
+import { useEntity } from "@backstage/plugin-catalog-react";
+import {
+  useIncidentList,
+  useIncidentAlertList,
+  useAlertList,
+  useAlertSourceList,
+  useIdentity,
+} from "../../hooks/useIncidentRequest";
+import { getEntityFieldID } from "../EntityIncidentCard";
+import { EntityAlertCard } from "./index";
+
+const mockEntity = {
+  kind: "Component",
+  metadata: { name: "my-service", namespace: "default" },
+};
+
+const mockIdentityLoaded = {
+  value: { identity: { dashboard_url: "https://app.incident.io" } },
+  loading: false,
+  error: undefined,
+};
+
+const mockSourcesLoaded = {
+  value: { alert_sources: [] },
+  loading: false,
+  error: undefined,
+};
+
+beforeEach(() => {
+  (useEntity as ReturnType<typeof vi.fn>).mockReturnValue({
+    entity: mockEntity,
+  });
+  (useIdentity as ReturnType<typeof vi.fn>).mockReturnValue(mockIdentityLoaded);
+  (useAlertSourceList as ReturnType<typeof vi.fn>).mockReturnValue(
+    mockSourcesLoaded,
+  );
+  (useApi as ReturnType<typeof vi.fn>).mockReturnValue({
+    getOptional: () => "01FIELD123",
+    getOptionalString: () => undefined,
+  });
+});
+
+describe("EntityAlertCard", () => {
+  it("should show MissingConfigCard when getEntityFieldID returns undefined", () => {
+    (getEntityFieldID as ReturnType<typeof vi.fn>).mockReturnValue(undefined);
+    (useIncidentList as ReturnType<typeof vi.fn>).mockReturnValue({
+      value: undefined,
+      loading: false,
+      error: undefined,
+    });
+    (useIncidentAlertList as ReturnType<typeof vi.fn>).mockReturnValue({
+      value: undefined,
+      loading: false,
+      error: undefined,
+    });
+    (useAlertList as ReturnType<typeof vi.fn>).mockReturnValue({
+      value: undefined,
+      loading: false,
+      error: undefined,
+    });
+
+    render(<EntityAlertCard />);
+
+    expect(
+      screen.getByText(/No custom field configuration was found/i),
+    ).toBeInTheDocument();
+  });
+
+  it("should show progress when a hook is loading", () => {
+    (getEntityFieldID as ReturnType<typeof vi.fn>).mockReturnValue("01FIELD123");
+    (useIncidentList as ReturnType<typeof vi.fn>).mockReturnValue({
+      value: undefined,
+      loading: true,
+      error: undefined,
+    });
+    (useIncidentAlertList as ReturnType<typeof vi.fn>).mockReturnValue({
+      value: undefined,
+      loading: false,
+      error: undefined,
+    });
+    (useAlertList as ReturnType<typeof vi.fn>).mockReturnValue({
+      value: undefined,
+      loading: false,
+      error: undefined,
+    });
+
+    render(<EntityAlertCard />);
+
+    expect(screen.getByTestId("progress")).toBeInTheDocument();
+  });
+
+  it("should show 'No alerts.' when incidentIds is empty", () => {
+    (getEntityFieldID as ReturnType<typeof vi.fn>).mockReturnValue("01FIELD123");
+    (useIncidentList as ReturnType<typeof vi.fn>).mockReturnValue({
+      value: { incidents: [] },
+      loading: false,
+      error: undefined,
+    });
+    (useIncidentAlertList as ReturnType<typeof vi.fn>).mockReturnValue({
+      value: { incident_alerts: [] },
+      loading: false,
+      error: undefined,
+    });
+    (useAlertList as ReturnType<typeof vi.fn>).mockReturnValue({
+      value: { alerts: [] },
+      loading: false,
+      error: undefined,
+    });
+
+    render(<EntityAlertCard />);
+
+    expect(screen.getByText("No alerts.")).toBeInTheDocument();
+  });
+
+  it("should show alert count and AlertListItem when alerts are linked", () => {
+    (getEntityFieldID as ReturnType<typeof vi.fn>).mockReturnValue("01FIELD123");
+    (useIncidentList as ReturnType<typeof vi.fn>).mockReturnValue({
+      value: { incidents: [{ id: "inc-1" }] },
+      loading: false,
+      error: undefined,
+    });
+    (useIncidentAlertList as ReturnType<typeof vi.fn>).mockReturnValue({
+      value: { incident_alerts: [{ alert: { id: "alert-1" } }] },
+      loading: false,
+      error: undefined,
+    });
+    (useAlertList as ReturnType<typeof vi.fn>).mockReturnValue({
+      value: {
+        alerts: [
+          {
+            id: "alert-1",
+            title: "High error rate",
+            status: "firing",
+            alert_source_id: "src-1",
+            attributes: [],
+          },
+        ],
+      },
+      loading: false,
+      error: undefined,
+    });
+
+    render(<EntityAlertCard />);
+
+    expect(
+      screen.getByText((_, el) => {
+        if (!el) return false;
+        return (
+          el.tagName === "H6" &&
+          !!el.textContent?.includes("There are") &&
+          !!el.textContent?.includes("1") &&
+          !!el.textContent?.includes("firing")
+        );
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("alert-alert-1")).toBeInTheDocument();
+  });
+
+  it("should render a refresh button", () => {
+    (getEntityFieldID as ReturnType<typeof vi.fn>).mockReturnValue("01FIELD123");
+    (useIncidentList as ReturnType<typeof vi.fn>).mockReturnValue({
+      value: { incidents: [] },
+      loading: false,
+      error: undefined,
+    });
+    (useIncidentAlertList as ReturnType<typeof vi.fn>).mockReturnValue({
+      value: { incident_alerts: [] },
+      loading: false,
+      error: undefined,
+    });
+    (useAlertList as ReturnType<typeof vi.fn>).mockReturnValue({
+      value: { alerts: [] },
+      loading: false,
+      error: undefined,
+    });
+
+    render(<EntityAlertCard />);
+
+    expect(screen.getByRole("button", { name: "Refresh" })).toBeInTheDocument();
+  });
+
+  it("should render status filter tabs", () => {
+    (getEntityFieldID as ReturnType<typeof vi.fn>).mockReturnValue("01FIELD123");
+    (useIncidentList as ReturnType<typeof vi.fn>).mockReturnValue({
+      value: { incidents: [] },
+      loading: false,
+      error: undefined,
+    });
+    (useIncidentAlertList as ReturnType<typeof vi.fn>).mockReturnValue({
+      value: { incident_alerts: [] },
+      loading: false,
+      error: undefined,
+    });
+    (useAlertList as ReturnType<typeof vi.fn>).mockReturnValue({
+      value: { alerts: [] },
+      loading: false,
+      error: undefined,
+    });
+
+    render(<EntityAlertCard />);
+
+    expect(screen.getByRole("tab", { name: "Firing" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "Resolved" })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: "All" })).toBeInTheDocument();
+  });
+});

--- a/incident/src/components/EntityAlertCard/index.tsx
+++ b/incident/src/components/EntityAlertCard/index.tsx
@@ -58,7 +58,7 @@ export const EntityAlertCard = () => {
   const entityFieldID = getEntityFieldID(config, entity);
   const entityID = `${entity.metadata.namespace}/${entity.metadata.name}`;
 
-  //query for incidents associated with this entity
+  // query for incidents associated with this entity
   const incidentQuery = new URLSearchParams();
   incidentQuery.set(`custom_field[${entityFieldID}][one_of]`, entityID);
 
@@ -66,7 +66,7 @@ export const EntityAlertCard = () => {
     useIncidentList(incidentQuery, [reload]);
   const incidentIds = (incidentsResponse?.incidents ?? []).map(i => i.id);
 
-  //query for alerts linked to those incidents
+  // query for alerts linked to those incidents
   const { value: incidentAlertsResponse, loading: incidentAlertsLoading } =
     useIncidentAlertList(incidentIds, [reload]);
   const linkedAlertIds = new Set(
@@ -78,7 +78,7 @@ export const EntityAlertCard = () => {
   const { value: sourcesResponse } = useAlertSourceList();
   const { value: identityResponse } = useIdentity();
 
-  //get alerts for this entity's incidents
+  // get alerts for this entity's incidents
   const allAlerts = alertsResponse?.alerts ?? [];
   const alerts = incidentIds.length > 0
     ? allAlerts.filter(a => linkedAlertIds.has(a.id))

--- a/incident/src/components/EntityAlertCard/index.tsx
+++ b/incident/src/components/EntityAlertCard/index.tsx
@@ -1,0 +1,168 @@
+import { Progress } from "@backstage/core-components";
+import { configApiRef, useApi } from "@backstage/core-plugin-api";
+import { useEntity } from "@backstage/plugin-catalog-react";
+import {
+  Box,
+  Card,
+  CardContent,
+  CardHeader,
+  Divider,
+  IconButton,
+  List,
+  Tab,
+  Tabs,
+  Typography,
+} from "@material-ui/core";
+import Link from "@material-ui/core/Link";
+import { Alert } from "@material-ui/lab";
+import CachedIcon from "@material-ui/icons/Cached";
+import { useState } from "react";
+import {
+  useAlertList,
+  useAlertSourceList,
+  useIdentity,
+  useIncidentAlertList,
+  useIncidentList,
+} from "../../hooks/useIncidentRequest";
+import { getEntityFieldID } from "../EntityIncidentCard";
+import { AlertListItem } from "../AlertListItem";
+
+type StatusFilter = "firing" | "resolved" | undefined;
+
+const STATUS_TABS: { label: string; value: StatusFilter }[] = [
+  { label: "Firing", value: "firing" },
+  { label: "Resolved", value: "resolved" },
+  { label: "All", value: undefined },
+];
+
+const IncorrectConfigCard = () => (
+  <Card>
+    <CardHeader title="Alerts" />
+    <Divider />
+    <CardContent>
+      <Typography variant="subtitle1">
+        No custom field configuration was found. In order to display alerts,
+        this entity must be mapped to an incident.io custom field ID in
+        Backstage's app-config.yaml.
+      </Typography>
+    </CardContent>
+  </Card>
+);
+
+export const EntityAlertCard = () => {
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("firing");
+  const [reload, setReload] = useState(false);
+
+  const config = useApi(configApiRef);
+  const { entity } = useEntity();
+  const entityFieldID = getEntityFieldID(config, entity);
+  const entityID = `${entity.metadata.namespace}/${entity.metadata.name}`;
+
+  //query for incidents associated with this entity
+  const incidentQuery = new URLSearchParams();
+  incidentQuery.set(`custom_field[${entityFieldID}][one_of]`, entityID);
+
+  const { value: incidentsResponse, loading: incidentsLoading } =
+    useIncidentList(incidentQuery, [reload]);
+  const incidentIds = (incidentsResponse?.incidents ?? []).map(i => i.id);
+
+  //query for alerts linked to those incidents
+  const { value: incidentAlertsResponse, loading: incidentAlertsLoading } =
+    useIncidentAlertList(incidentIds, [reload]);
+  const linkedAlertIds = new Set(
+    (incidentAlertsResponse?.incident_alerts ?? []).map(ia => ia.alert.id),
+  );
+
+  const { value: alertsResponse, loading: alertsLoading, error } =
+    useAlertList(statusFilter, [reload]);
+  const { value: sourcesResponse } = useAlertSourceList();
+  const { value: identityResponse } = useIdentity();
+
+  //get alerts for this entity's incidents
+  const allAlerts = alertsResponse?.alerts ?? [];
+  const alerts = incidentIds.length > 0
+    ? allAlerts.filter(a => linkedAlertIds.has(a.id))
+    : [];
+
+  const baseUrl = identityResponse?.identity.dashboard_url ?? "";
+
+  const sourceById = Object.fromEntries(
+    (sourcesResponse?.alert_sources ?? []).map(s => [s.id, s]),
+  );
+
+  const currentTabIndex = STATUS_TABS.findIndex(t => t.value === statusFilter);
+  if (!entityFieldID) {
+    return <IncorrectConfigCard />;
+  }
+
+  if (incidentsLoading || incidentAlertsLoading || alertsLoading) {
+    return <Progress />;
+  }
+
+  return (
+    <Card>
+      <CardHeader
+        title="incident.io Alerts"
+        action={
+          <>
+            <IconButton
+              component={Link}
+              aria-label="Refresh"
+              disabled={false}
+              title="Refresh"
+              onClick={() => setReload(!reload)}
+            >
+              <CachedIcon />
+            </IconButton>
+          </>
+        }
+      />
+      <Divider />
+      <Tabs
+        value={currentTabIndex}
+        onChange={(_, idx) => setStatusFilter(STATUS_TABS[idx].value)}
+        indicatorColor="primary"
+        textColor="primary"
+      >
+        {STATUS_TABS.map(tab => (
+          <Tab key={tab.label} label={tab.label} />
+        ))}
+      </Tabs>
+      <Divider />
+      <CardContent>
+        {error && <Alert severity="error">{error.message}</Alert>}
+        {!error && alerts.length === 0 && (
+          <Typography variant="subtitle1">No alerts.</Typography>
+        )}
+        {!error && alerts.length > 0 && (
+          <>
+            <Typography variant="subtitle1">
+              There are <strong>{alerts.length}</strong>{" "}
+              {statusFilter ?? ""} alerts.
+            </Typography>
+            <Box style={{ maxHeight: 400, overflowY: "auto" }}>
+              <List dense>
+                {alerts.map(alert => (
+                  <AlertListItem
+                    key={alert.id}
+                    alert={alert}
+                    baseUrl={baseUrl}
+                    source={sourceById[alert.alert_source_id]?.name ?? "-"}
+                    priority={alert.attributes.find(a => a.attribute.name === "Priority")?.value?.label}
+                  />
+                ))}
+              </List>
+            </Box>
+          </>
+        )}
+        {baseUrl && (
+          <Typography variant="subtitle1">
+            <Link target="_blank" href={`${baseUrl}/on-call/alerts`}>
+              View all alerts
+            </Link>
+          </Typography>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/incident/src/components/EntityIncidentCard/index.tsx
+++ b/incident/src/components/EntityIncidentCard/index.tsx
@@ -187,7 +187,7 @@ export const EntityIncidentCard = ({
 // to this type of entity.
 //
 // In practice, this will be kind=Component => ID of Affected components field.
-function getEntityFieldID(config: ConfigApi, entity: Entity) {
+export function getEntityFieldID(config: ConfigApi, entity: Entity) {
   switch (entity.kind) {
     case "API":
       return config.getOptional("incident.fields.api");

--- a/incident/src/components/HomePageAlertCard/Content.test.tsx
+++ b/incident/src/components/HomePageAlertCard/Content.test.tsx
@@ -3,7 +3,6 @@ import { TestApiProvider, renderInTestApp } from "@backstage/test-utils";
 import { vi, type Mocked } from "vitest";
 import { IncidentApi, IncidentApiRef } from "../../api/client";
 import { HomePageAlertCardContent } from "./Content";
-import { ContextProvider } from "./Context";
 
 const mockAlert = {
   id: "alert-1",
@@ -30,46 +29,26 @@ const makeIncidentApi = (
   }),
 });
 
+const renderContent = (alerts: typeof mockAlert[]) =>
+  renderInTestApp(
+    <TestApiProvider apis={[[IncidentApiRef, makeIncidentApi(alerts)]]}>
+      <HomePageAlertCardContent />
+    </TestApiProvider>,
+  );
+
 describe("HomePageAlertCardContent", () => {
   it("should render an alert chip when an alert is returned", async () => {
-    const mockIncidentApi = makeIncidentApi([mockAlert]);
-
-    const { findByTestId } = await renderInTestApp(
-      <TestApiProvider apis={[[IncidentApiRef, mockIncidentApi]]}>
-        <ContextProvider status="firing">
-          <HomePageAlertCardContent />
-        </ContextProvider>
-      </TestApiProvider>,
-    );
-
+    const { findByTestId } = await renderContent([mockAlert]);
     expect(await findByTestId("chip-firing")).toBeInTheDocument();
   });
 
   it("should show empty state when API returns no alerts", async () => {
-    const mockIncidentApi = makeIncidentApi([]);
-
-    const { findByText } = await renderInTestApp(
-      <TestApiProvider apis={[[IncidentApiRef, mockIncidentApi]]}>
-        <ContextProvider status="firing">
-          <HomePageAlertCardContent />
-        </ContextProvider>
-      </TestApiProvider>,
-    );
-
+    const { findByText } = await renderContent([]);
     expect(await findByText(/No firing alerts\./i)).toBeInTheDocument();
   });
 
   it("should render Firing, Resolved, and All tabs", async () => {
-    const mockIncidentApi = makeIncidentApi([]);
-
-    const { findByText } = await renderInTestApp(
-      <TestApiProvider apis={[[IncidentApiRef, mockIncidentApi]]}>
-        <ContextProvider status="firing">
-          <HomePageAlertCardContent />
-        </ContextProvider>
-      </TestApiProvider>,
-    );
-
+    const { findByText } = await renderContent([]);
     expect(await findByText("Firing")).toBeInTheDocument();
     expect(await findByText("Resolved")).toBeInTheDocument();
     expect(await findByText("All")).toBeInTheDocument();

--- a/incident/src/components/HomePageAlertCard/Content.test.tsx
+++ b/incident/src/components/HomePageAlertCard/Content.test.tsx
@@ -1,0 +1,77 @@
+/// <reference types="@testing-library/jest-dom" />
+import { TestApiProvider, renderInTestApp } from "@backstage/test-utils";
+import { vi, type Mocked } from "vitest";
+import { IncidentApi, IncidentApiRef } from "../../api/client";
+import { HomePageAlertCardContent } from "./Content";
+import { ContextProvider } from "./Context";
+
+const mockAlert = {
+  id: "alert-1",
+  title: "High error rate",
+  status: "firing",
+  created_at: "2026-04-09T12:00:00Z",
+  updated_at: "2026-04-09T12:00:00Z",
+  deduplication_key: "abc123",
+  alert_source_id: "src-1",
+  attributes: [],
+};
+
+const makeIncidentApi = (
+  alerts: typeof mockAlert[],
+): Mocked<Partial<IncidentApi>> => ({
+  request: vi.fn().mockImplementation(({ path }: { path: string }) => {
+    if (path.startsWith("/v2/alerts")) {
+      return Promise.resolve({ alerts });
+    }
+    if (path === "/v2/alert_sources") {
+      return Promise.resolve({ alert_sources: [] });
+    }
+    return Promise.resolve({});
+  }),
+});
+
+describe("HomePageAlertCardContent", () => {
+  it("should render an alert chip when an alert is returned", async () => {
+    const mockIncidentApi = makeIncidentApi([mockAlert]);
+
+    const { findByTestId } = await renderInTestApp(
+      <TestApiProvider apis={[[IncidentApiRef, mockIncidentApi]]}>
+        <ContextProvider status="firing">
+          <HomePageAlertCardContent />
+        </ContextProvider>
+      </TestApiProvider>,
+    );
+
+    expect(await findByTestId("chip-firing")).toBeInTheDocument();
+  });
+
+  it("should show empty state when API returns no alerts", async () => {
+    const mockIncidentApi = makeIncidentApi([]);
+
+    const { findByText } = await renderInTestApp(
+      <TestApiProvider apis={[[IncidentApiRef, mockIncidentApi]]}>
+        <ContextProvider status="firing">
+          <HomePageAlertCardContent />
+        </ContextProvider>
+      </TestApiProvider>,
+    );
+
+    expect(await findByText(/No firing alerts\./i)).toBeInTheDocument();
+  });
+
+  it("should render Firing, Resolved, and All tabs", async () => {
+    const mockIncidentApi = makeIncidentApi([]);
+
+    const { findByText } = await renderInTestApp(
+      <TestApiProvider apis={[[IncidentApiRef, mockIncidentApi]]}>
+        <ContextProvider status="firing">
+          <HomePageAlertCardContent />
+        </ContextProvider>
+      </TestApiProvider>,
+    );
+
+    expect(await findByText("Firing")).toBeInTheDocument();
+    expect(await findByText("Resolved")).toBeInTheDocument();
+    expect(await findByText("All")).toBeInTheDocument();
+  });
+});

--- a/incident/src/components/HomePageAlertCard/Content.tsx
+++ b/incident/src/components/HomePageAlertCard/Content.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import { Progress } from "@backstage/core-components";
+import { configApiRef, useApi } from "@backstage/core-plugin-api";
+import Link from "@material-ui/core/Link";
+import { Alert } from "@material-ui/lab";
+import { Box, Divider, List, Tab, Tabs, Typography } from "@material-ui/core";
+import { useAlertList, useAlertSourceList } from "../../hooks/useIncidentRequest";
+import { AlertListItem } from "../AlertListItem";
+
+type StatusFilter = "firing" | "resolved" | undefined;
+
+const STATUS_TABS: { label: string; value: StatusFilter }[] = [
+  { label: "Firing", value: "firing" },
+  { label: "Resolved", value: "resolved" },
+  { label: "All", value: undefined },
+];
+
+export const HomePageAlertCardContent = () => {
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("firing");
+
+  const config = useApi(configApiRef);
+  const baseUrl =
+    config.getOptionalString("incident.baseUrl") || "https://app.incident.io";
+
+  const { loading, error, value } = useAlertList(statusFilter, [statusFilter]);
+  const { value: sourcesResponse } = useAlertSourceList();
+
+  const alerts = value?.alerts ?? [];
+  const sourceById = Object.fromEntries(
+    (sourcesResponse?.alert_sources ?? []).map(s => [s.id, s]),
+  );
+
+  const currentTabIndex = STATUS_TABS.findIndex(t => t.value === statusFilter);
+
+  if (loading) return <Progress />;
+  if (error) return <Alert severity="error">{error.message}</Alert>;
+
+  return (
+    <>
+      <Tabs
+        value={currentTabIndex}
+        onChange={(_, idx) => setStatusFilter(STATUS_TABS[idx].value)}
+        indicatorColor="primary"
+        textColor="primary"
+        style={{ minHeight: "auto" }}
+      >
+        {STATUS_TABS.map(tab => (
+          <Tab key={tab.label} label={tab.label} style={{ minHeight: "auto", padding: "0px 12px" }} />
+        ))}
+      </Tabs>
+      <Divider />
+      {alerts.length > 0 && (
+        <Typography variant="subtitle1">
+          There are <strong>{alerts.length}</strong> {statusFilter ?? ""} alerts.
+        </Typography>
+      )}
+      {alerts.length === 0 && (
+        <Typography variant="subtitle1">No {statusFilter ?? ""} alerts.</Typography>
+      )}
+      <Box style={{ maxHeight: 400, overflowY: "auto" }}>
+        <List dense>
+          {alerts.map(alert => (
+            <AlertListItem
+              key={alert.id}
+              alert={alert}
+              baseUrl={baseUrl}
+              source={sourceById[alert.alert_source_id]?.name ?? "-"}
+              priority={alert.attributes.find(a => a.attribute.name === "Priority")?.value?.label}
+            />
+          ))}
+        </List>
+      </Box>
+      <Typography variant="subtitle1">
+        Click to{" "}
+        <Link target="_blank" href={`${baseUrl}/on-call/alerts`}>
+          see more.
+        </Link>
+      </Typography>
+    </>
+  );
+};
+
+export const Content = () => {
+  return <HomePageAlertCardContent />;
+};

--- a/incident/src/components/HomePageAlertCard/index.tsx
+++ b/incident/src/components/HomePageAlertCard/index.tsx
@@ -1,0 +1,1 @@
+export { Content } from "./Content";

--- a/incident/src/components/IncidentListItem/index.tsx
+++ b/incident/src/components/IncidentListItem/index.tsx
@@ -28,23 +28,24 @@ import {
 import OpenInBrowserIcon from "@material-ui/icons/OpenInBrowser";
 import { definitions } from "../../api/types";
 
-const useStyles = makeStyles<BackstageTheme>((theme) => ({
+export const useStyles = makeStyles<BackstageTheme>((theme) => ({
   listItemPrimary: {
     display: "flex", // vertically align with chip
     fontWeight: "bold",
+    gap: theme.spacing(1),    
   },
   warning: {
-    borderColor: theme.palette.status.warning,
-    color: theme.palette.status.warning,
+    borderColor: theme.palette.warning,
+    color: theme.palette.warning,
     "& *": {
-      color: theme.palette.status.warning,
+      color: theme.palette.warning,
     },
   },
   error: {
-    borderColor: theme.palette.status.error,
-    color: theme.palette.status.error,
+    borderColor: theme.palette.error,
+    color: theme.palette.error,
     "& *": {
-      color: theme.palette.status.error,
+      color: theme.palette.error,
     },
   },
 }));

--- a/incident/src/components/IncidentListItem/index.tsx
+++ b/incident/src/components/IncidentListItem/index.tsx
@@ -35,17 +35,17 @@ export const useStyles = makeStyles<BackstageTheme>((theme) => ({
     gap: theme.spacing(1),    
   },
   warning: {
-    borderColor: theme.palette.warning,
-    color: theme.palette.warning,
+    borderColor: theme.palette.warning.main,
+    color: theme.palette.warning.main,
     "& *": {
-      color: theme.palette.warning,
+      color: theme.palette.warning.main,
     },
   },
   error: {
-    borderColor: theme.palette.error,
-    color: theme.palette.error,
+    borderColor: theme.palette.error.main,
+    color: theme.palette.error.main,
     "& *": {
-      color: theme.palette.error,
+      color: theme.palette.error.main,
     },
   },
 }));

--- a/incident/src/components/IncidentListItem/index.tsx
+++ b/incident/src/components/IncidentListItem/index.tsx
@@ -48,6 +48,13 @@ export const useStyles = makeStyles<BackstageTheme>((theme) => ({
       color: theme.palette.error.main,
     },
   },
+  success: {
+    borderColor: theme.palette.success.main,
+    color: theme.palette.success.main,
+    "& *": {
+      color: theme.palette.success.main,
+    },
+  },
 }));
 
 // Single item in the list of on-going incidents.

--- a/incident/src/hooks/useIncidentRequest.test.ts
+++ b/incident/src/hooks/useIncidentRequest.test.ts
@@ -7,7 +7,6 @@ import {
   useIncidentAlertList,
   useAlertSourceList,
   useAlertAttributeList,
-  useAlert,
 } from "./useIncidentRequest";
 
 // Mock @backstage/core-plugin-api so useApi returns our fake client
@@ -191,33 +190,6 @@ describe("useAlertAttributeList", () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(result.current.value).toEqual(mockResponse);
-    expect(result.current.error).toBeUndefined();
-  });
-});
-
-describe("useAlert", () => {
-  it("should return a single alert from the API", async () => {
-    const mockResponse = {
-      id: "alert-1",
-      title: "High error rate",
-      status: "firing",
-      created_at: "2026-04-09T12:00:00Z",
-      updated_at: "2026-04-09T12:00:00Z",
-      deduplication_key: "abc123",
-      alert_source_id: "src-1",
-      attributes: [],
-    };
-    const mockRequest = vi.fn().mockResolvedValue(mockResponse);
-    (useApi as ReturnType<typeof vi.fn>).mockReturnValue({ request: mockRequest });
-
-    const { result } = renderHook(() => useAlert("alert-1"));
-
-    await waitFor(() => expect(result.current.loading).toBe(false));
-
-    expect(result.current.value).toEqual(mockResponse);
-    expect(mockRequest).toHaveBeenCalledWith(
-      expect.objectContaining({ path: "/v2/alerts/alert-1" }),
-    );
     expect(result.current.error).toBeUndefined();
   });
 });

--- a/incident/src/hooks/useIncidentRequest.test.ts
+++ b/incident/src/hooks/useIncidentRequest.test.ts
@@ -1,6 +1,14 @@
-import { renderHook, waitFor } from "@testing-library/react";
+import { renderHook, waitFor, act } from "@testing-library/react";
 import { vi } from "vitest";
-import { useIncidentList, useIdentity } from "./useIncidentRequest";
+import {
+  useIncidentList,
+  useIdentity,
+  useAlertList,
+  useIncidentAlertList,
+  useAlertSourceList,
+  useAlertAttributeList,
+  useAlert,
+} from "./useIncidentRequest";
 
 // Mock @backstage/core-plugin-api so useApi returns our fake client
 vi.mock("@backstage/core-plugin-api", () => ({
@@ -24,6 +32,192 @@ describe("useIncidentList", () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(result.current.value).toEqual(mockResponse);
+    expect(result.current.error).toBeUndefined();
+  });
+});
+
+describe("useAlertList", () => {
+  const mockAlert = {
+    id: "01KNS58MGQGMHDT8C2X8094MAF",
+    title: "High error rate",
+    description: "CPU exceeded 75% for 5 minutes",
+    status: "firing",
+    created_at: "2026-04-09T12:00:00Z",
+    updated_at: "2026-04-09T12:00:00Z",
+    deduplication_key: "abc123",
+    alert_source_id: "src-1",
+    source_url: "https://datadog.com/alerts/123",
+    attributes: [],
+  };
+  const mockResponse = { alerts: [mockAlert], pagination_meta: { page_size: 25 } };
+
+  it("should return alerts from the API", async () => {
+    (useApi as ReturnType<typeof vi.fn>).mockReturnValue({
+      request: vi.fn().mockResolvedValue(mockResponse),
+    });
+
+    const { result } = renderHook(() => useAlertList());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.value).toEqual(mockResponse);
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it("passes the status filter as a query param", async () => {
+    const mockRequest = vi.fn().mockResolvedValue(mockResponse);
+    (useApi as ReturnType<typeof vi.fn>).mockReturnValue({ request: mockRequest });
+
+    const { result } = renderHook(() => useAlertList("firing"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ path: expect.stringContaining("status%5Bone_of%5D=firing") }),
+    );
+  });
+
+  it("does not pass a status param when status is undefined", async () => {
+    const mockRequest = vi.fn().mockResolvedValue(mockResponse);
+    (useApi as ReturnType<typeof vi.fn>).mockReturnValue({ request: mockRequest });
+
+    const { result } = renderHook(() => useAlertList(undefined));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ path: expect.not.stringContaining("status") }),
+    );
+  });
+
+  it("re-fetches when deps change", async () => {
+    const mockRequest = vi.fn().mockResolvedValue(mockResponse);
+    (useApi as ReturnType<typeof vi.fn>).mockReturnValue({ request: mockRequest });
+
+    let reload = false;
+    const { result, rerender } = renderHook(() => useAlertList("firing", [reload]));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+
+    act(() => { reload = true; });
+    rerender();
+
+    await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(2));
+  });
+});
+
+describe("useIncidentAlertList", () => {
+  it("returns empty immediately when no incident IDs are given", async () => {
+    (useApi as ReturnType<typeof vi.fn>).mockReturnValue({
+      request: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useIncidentAlertList([]));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.value?.incident_alerts).toEqual([]);
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it("makes one request per incident ID and flattens results", async () => {
+    const mockRequest = vi.fn()
+      .mockResolvedValueOnce({ incident_alerts: [{ id: "ia-1", alert: { id: "a-1" }, incident: { id: "inc-1" } }], pagination_meta: { page_size: 25 } })
+      .mockResolvedValueOnce({ incident_alerts: [{ id: "ia-2", alert: { id: "a-2" }, incident: { id: "inc-2" } }], pagination_meta: { page_size: 25 } });
+
+    (useApi as ReturnType<typeof vi.fn>).mockReturnValue({ request: mockRequest });
+
+    const { result } = renderHook(() => useIncidentAlertList(["inc-1", "inc-2"]));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockRequest).toHaveBeenCalledTimes(2);
+    expect(result.current.value?.incident_alerts).toHaveLength(2);
+    expect(result.current.value?.incident_alerts.map(ia => ia.id)).toEqual(["ia-1", "ia-2"]);
+  });
+
+  it("re-fetches when deps change even if incident IDs are unchanged", async () => {
+    const mockRequest = vi.fn().mockResolvedValue({
+      incident_alerts: [{ id: "ia-1", alert: { id: "a-1" }, incident: { id: "inc-1" } }],
+      pagination_meta: { page_size: 25 },
+    });
+    (useApi as ReturnType<typeof vi.fn>).mockReturnValue({ request: mockRequest });
+
+    let reload = false;
+    const { result, rerender } = renderHook(() => useIncidentAlertList(["inc-1"], [reload]));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockRequest).toHaveBeenCalledTimes(1);
+
+    act(() => { reload = true; });
+    rerender();
+
+    await waitFor(() => expect(mockRequest).toHaveBeenCalledTimes(2));
+  });
+});
+
+describe("useAlertSourceList", () => {
+  it("should return alert sources from the API", async () => {
+    const mockResponse = {
+      alert_sources: [{ id: "src-1", name: "Datadog", source_type: "datadog" }],
+    };
+    (useApi as ReturnType<typeof vi.fn>).mockReturnValue({
+      request: vi.fn().mockResolvedValue(mockResponse),
+    });
+
+    const { result } = renderHook(() => useAlertSourceList());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.value).toEqual(mockResponse);
+    expect(result.current.error).toBeUndefined();
+  });
+});
+
+describe("useAlertAttributeList", () => {
+  it("should return alert attributes from the API", async () => {
+    const mockResponse = {
+      alert_attributes: [
+        { id: "attr-1", name: "Priority", type: "string", array: false, required: false },
+      ],
+    };
+    (useApi as ReturnType<typeof vi.fn>).mockReturnValue({
+      request: vi.fn().mockResolvedValue(mockResponse),
+    });
+
+    const { result } = renderHook(() => useAlertAttributeList());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.value).toEqual(mockResponse);
+    expect(result.current.error).toBeUndefined();
+  });
+});
+
+describe("useAlert", () => {
+  it("should return a single alert from the API", async () => {
+    const mockResponse = {
+      id: "alert-1",
+      title: "High error rate",
+      status: "firing",
+      created_at: "2026-04-09T12:00:00Z",
+      updated_at: "2026-04-09T12:00:00Z",
+      deduplication_key: "abc123",
+      alert_source_id: "src-1",
+      attributes: [],
+    };
+    const mockRequest = vi.fn().mockResolvedValue(mockResponse);
+    (useApi as ReturnType<typeof vi.fn>).mockReturnValue({ request: mockRequest });
+
+    const { result } = renderHook(() => useAlert("alert-1"));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.value).toEqual(mockResponse);
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ path: "/v2/alerts/alert-1" }),
+    );
     expect(result.current.error).toBeUndefined();
   });
 });

--- a/incident/src/hooks/useIncidentRequest.ts
+++ b/incident/src/hooks/useIncidentRequest.ts
@@ -21,6 +21,74 @@ export const useIncidentList = (
   return { loading, error, value };
 };
 
+export const useAlertList = (status?: "firing" | "resolved", deps?: DependencyList) => {
+  const IncidentApi = useApi(IncidentApiRef);
+
+  const { value, loading, error } = useAsync(async () => {
+    const query = new URLSearchParams({ page_size: "25" });
+    if (status) query.set("status[one_of]", status);
+    return await IncidentApi.request<
+      definitions["AlertsV2ListResponseBody"]
+    >({
+      path: `/v2/alerts?${query.toString()}`,
+    });
+  }, [status, ...(deps ?? [])]);
+
+  return { loading, error, value };
+};
+
+export const useAlertSourceList = () => {
+  const IncidentApi = useApi(IncidentApiRef);
+
+  const { value, loading, error } = useAsync(async () => {
+    return await IncidentApi.request<
+      definitions["AlertSourcesV2ListResponseBody"]
+    >({
+      path: `/v2/alert_sources`,
+    });
+  });
+
+  return { loading, error, value };
+};
+
+export const useIncidentAlertList = (incidentIds: string[], deps?: DependencyList) => {
+  const IncidentApi = useApi(IncidentApiRef);
+
+  const { value, loading, error } = useAsync(async () => {
+    if (incidentIds.length === 0) {
+      return { incident_alerts: [], pagination_meta: { page_size: 25 } };
+    }
+    const results = await Promise.all(
+      incidentIds.map(id =>
+        IncidentApi.request<definitions["IncidentAlertsV2ListResponseBody"]>({
+          path: `/v2/incident_alerts?incident_id=${id}&page_size=25`,
+        }),
+      ),
+    );
+    return {
+      incident_alerts: results.flatMap(r => r.incident_alerts),
+      pagination_meta: { page_size: 25 },
+    };
+  }, [incidentIds.join(","), ...(deps ?? [])]);
+
+  return { loading, error, value };
+};
+
+export const useAlertAttributeList = () => {
+  const IncidentApi = useApi(IncidentApiRef);
+
+  const { value, loading, error } = useAsync(async () => {
+    return await IncidentApi.request<
+      definitions["AlertAttributesV2ListResponseBody"]
+    >({
+      path: `/v2/alert_attributes`,
+    });
+  });
+
+  return { loading, error, value };
+};
+
+
 export const useIdentity = () => {
   const IncidentApi = useApi(IncidentApiRef);
 

--- a/incident/src/index.ts
+++ b/incident/src/index.ts
@@ -16,5 +16,7 @@
 export {
   incidentPlugin,
   EntityIncidentCard,
+  EntityAlertCard,
   HomePageIncidentCard,
+  HomePageAlertCard,
 } from "./plugin";

--- a/incident/src/plugin.ts
+++ b/incident/src/plugin.ts
@@ -58,6 +58,28 @@ export const EntityIncidentCard = incidentPlugin.provide(
   }),
 );
 
+export const EntityAlertCard = incidentPlugin.provide(
+  createComponentExtension({
+    name: "EntityAlertCard",
+    component: {
+      lazy: () =>
+        import("./components/EntityAlertCard").then(
+          (m) => m.EntityAlertCard,
+        ),
+    },
+  }),
+);
+
+export const HomePageAlertCard: (
+  props: CardExtensionProps<unknown>,
+) => JSX.Element = incidentPlugin.provide(
+  createCardExtension({
+    name: "HomePageAlertCard",
+    title: "Firing Alerts",
+    components: () => import("./components/HomePageAlertCard"),
+  }),
+);
+
 export const HomePageIncidentCard: (
   props: CardExtensionProps<unknown>,
 ) => JSX.Element = incidentPlugin.provide(


### PR DESCRIPTION
entityAlertCard queries alerts related to the incidents for the current entity, homePageAlertCard displays all alerts. Both cards have firing/resolved/all tabs to filter which alerts to display. Both use the shared AlertListItem. Added new hooks as well as unit tests. 

Also changed the spacing on the styling of the incident list item, and reused it in alert list item. 

homePageAlertCard:
<img width="1673" height="473" alt="Screenshot 2026-04-10 at 15 00 37" src="https://github.com/user-attachments/assets/63ac3f81-2cb5-49de-b95a-f129c3838ed9" />

entityAlertCard:
<img width="1120" height="852" alt="Screenshot 2026-04-10 at 15 06 22" src="https://github.com/user-attachments/assets/2887e1d5-ac83-4940-9d85-9ded4f3736c4" />
(incident card shown above it)
<!-- !review @rliddler -->
