### PR TITLE
fix: Add default filters

### DIFF
--- a/incident/src/alpha.tsx
+++ b/incident/src/alpha.tsx
@@ -31,7 +31,12 @@ const incidentApi = ApiBlueprint.make({
 const entityIncidentCard = EntityCardBlueprint.make({
   name: "EntityIncidentCard",
   params: {
-    loader: async () => 
+    filter: {
+      kind: {
+        $in: ["api", "component", "domain", "group", "system"],
+      }
+    },
+    loader: async () =>
       import("./components/EntityIncidentCard").then(m=><m.EntityIncidentCard />),
   },
 });
@@ -39,7 +44,12 @@ const entityIncidentCard = EntityCardBlueprint.make({
 const entityAlertCard = EntityCardBlueprint.make({
   name: "EntityAlertCard",
   params: {
-    loader: async () => 
+    filter: {
+      kind: {
+        $in: ["api", "component", "domain", "group", "system"],
+      }
+    },
+    loader: async () =>
       import("./components/EntityAlertCard").then(m=><m.EntityAlertCard />),
   }
 });
@@ -47,7 +57,12 @@ const entityAlertCard = EntityCardBlueprint.make({
 const entityOnCallCard = EntityCardBlueprint.make({
   name: "EntityOnCallCard",
   params: {
-    loader: async () => 
+    filter: {
+      kind: {
+        $in: ["api", "component", "domain", "group", "system"],
+      }
+    },
+    loader: async () =>
       import("./components/EntityOnCallCard").then(m=><m.EntityOnCallCard />),
   },
 });


### PR DESCRIPTION
Without this, someone using [feature discovery](https://backstage.io/docs/frontend-system/building-apps/installing-plugins#feature-discovery) will end up with the entity cards showing up on pages like User, which then leads to the `unrecognised entity kind` error being thrown

Upstream example of the filters [here](https://github.com/backstage/backstage/blob/3ef6078b7047e544d4631763d12593f230183b3a/plugins/catalog/src/alpha/entityCards.tsx#L60-L63)